### PR TITLE
Exit with code 0 when auto-fixing

### DIFF
--- a/json-sort.js
+++ b/json-sort.js
@@ -53,9 +53,8 @@ async function main() {
     const formattedHash = await fileHash.create(formattedFilePath);
     if (originalHash !== formattedHash) {
       const isStructuralDifference = await formatter.isStructuralDifference(originalFilePath, formattedFilePath);
-      exitCode = 1;
       if (argv.autofix) {
-        console.error(`Updating file ${originalFilePath} (${isStructuralDifference ? 'structure' : 'whitespace'}).`);
+        console.log(`Updating file ${originalFilePath} (${isStructuralDifference ? 'structure' : 'whitespace'}).`);
         try {
           await fs.cp(formattedFilePath, originalFilePath, { force: true });
         } catch (e) {
@@ -63,6 +62,7 @@ async function main() {
           continue;
         }
       } else {
+        exitCode = 1;
         console.error(`${originalFilePath} is not properly sorted (${isStructuralDifference ? 'structure' : 'whitespace'}).`);
       }
     }


### PR DESCRIPTION
When running the command with option `-- autofix`
it will do it's job and then exit with error code 1
which is confusing because it gives the feeling that something went wrong
although everything went fine and there were no problems.

In a shell script I have to catch this error but one will never know when something is actually going wrong.