### PR TITLE
Add known issues list.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "autofix",
     "jsdiff"
   ],
-  "eslint.useFlatConfig": true
+  "eslint.useFlatConfig": true,
+  "markdown.extension.toc.levels": "2..6"
 }


### PR DESCRIPTION
Closes #159.

Some of the changes in the JSON after sorting are not obvious and may be unexpected. For example, number formatting or Unicode escaping may be translated differently in the parse/sort/stringify loop due to the way `JSON.parse` and `JSON.stringify` work. It is not always possible to retain original user formatting.

This adds a "known issues" list to the README to capture things that may not be obvious.