### PR TITLE
Install the hook without requiring install-links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,4 +21,4 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: npm install -g npm
       - run: npm clean-install
-      - run: npm run build
+      - run: npm run verify

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,8 +6,8 @@
         "isDefault": true,
         "kind": "build"
       },
-      "label": "npm: build",
-      "script": "build",
+      "label": "npm: verify",
+      "script": "verify",
       "type": "npm"
     },
     {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,14 +17,7 @@ npm install
 npm run verify
 ```
 
-The lint/test script is deliberately named `verify` rather than `build`. pre-commit
-installs this hook with `npm install -g git+file://<clone>`, and npm only prepares a
-git-sourced package (materializing it into `node_modules`) when the manifest has one
-of `build`, `prepare`, `prepack`, `install`, `preinstall`, or `postinstall`. With one
-of those present, npm instead symlinks the package into a temporary git clone that it
-then deletes, so the `json-sort` executable dangles and the hook fails with
-`Executable json-sort not found` unless the consumer sets `npm config set
-install-links true`. Avoid adding scripts with any of those names.
+The lint/test script is deliberately named `verify` rather than `build`. pre-commit installs this hook with `npm install -g git+file://<clone>`, and npm only prepares a git-sourced package (materializing it into `node_modules`) when the manifest has one of `build`, `prepare`, `prepack`, `install`, `preinstall`, or `postinstall`. With one of those present, npm instead symlinks the package into a temporary git clone that it then deletes, so the `json-sort` executable dangles and the hook fails with `Executable json-sort not found` unless the consumer sets `npm config set install-links true`. Avoid adding scripts with any of those names.
 
 ## Test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,17 @@ Once you clone the repo, run `pre-commit install` to connect the pre-commit hook
 npm install
 
 # Do the lint/test cycle.
-npm run build
+npm run verify
 ```
+
+The lint/test script is deliberately named `verify` rather than `build`. pre-commit
+installs this hook with `npm install -g git+file://<clone>`, and npm only prepares a
+git-sourced package (materializing it into `node_modules`) when the manifest has one
+of `build`, `prepare`, `prepack`, `install`, `preinstall`, or `postinstall`. With one
+of those present, npm instead symlinks the package into a temporary git clone that it
+then deletes, so the `json-sort` executable dangles and the hook fails with
+`Executable json-sort not found` unless the consumer sets `npm config set
+install-links true`. Avoid adding scripts with any of those names.
 
 ## Test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tillig/json-sort-cli",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tillig/json-sort-cli",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "diff": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -39,5 +39,5 @@
     "test": "mocha",
     "verify": "npm run lint && npm run test"
   },
-  "version": "3.0.1"
+  "version": "3.0.2"
 }

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "url": "git+https://github.com/tillig/json-sort-cli.git"
   },
   "scripts": {
-    "build": "npm run lint && npm run test",
     "lint": "eslint .",
-    "test": "mocha"
+    "test": "mocha",
+    "verify": "npm run lint && npm run test"
   },
   "version": "3.0.1"
 }


### PR DESCRIPTION
## Problem

Consumers of this hook have to run `npm config set install-links true` or the hook
fails with:

```text
Executable `json-sort` not found
```

`markdownlint-cli`, another `language: node` pre-commit hook, does not require this.

## Why it happens

pre-commit (4.4+) installs `language: node` hooks with:

```text
npm install --allow-git=root -g git+file://<hook clone>
```

For a git source, npm/pacote decides whether to *prepare* the package based purely on
which lifecycle script names appear in the manifest. From `pacote/lib/git.js`
(`#prepareDir`), preparation runs only when the manifest declares one of:

`postinstall`, `build`, `preinstall`, `install`, `prepack`, `prepare`

When none are present, npm copies the package into `lib/node_modules` — a real
directory. When one *is* present, npm instead symlinks the package to its temporary
git clone under `~/.npm/_cacache/tmp/git-clone*`, then deletes that clone. The global
`bin/json-sort` symlink is created but points through a dangling link, so the
executable is missing at runtime.

`install-links=true` masks the bug by forcing npm to materialize the package.

Our `scripts` block had `build` — matching that list purely by name. `markdownlint-cli`'s
scripts (`test`, `fix`, `start`, `watch`, `invalid`, `precommit`) match none of them,
which is the entire reason it never needed `install-links`.

## Fix

Rename `build` to `verify`. It is not a pacote prepare trigger, so npm copies the
package and the executable resolves. No code changes, no packaging changes.

## Verification

Reproduced pre-commit's exact install command against a clone, with `install-links` unset:

| Package | Result |
| --- | --- |
| `main` (has `build`) | dangling symlink into `_cacache/tmp/git-clone*`, `json-sort` not found |
| `markdownlint-cli` | real directory, binary works |
| this branch (`verify`) | real directory, binary works |

Also confirmed by bisecting script names on this repo: `build`, `prepare`, `prepack`,
and `postinstall` each reproduce the dangling symlink; `lint`, `test`, and an arbitrary
`foo` do not.

Additionally verified:

- `npm run verify` — lint clean, 17 tests passing.
- End-to-end `pre-commit run` with `install-links` unset: hook executes and correctly
  reports/fixes unsorted JSON (previously `Executable json-sort not found`).
- `install-links=true` still works, so anyone who already set it is unaffected.
- `npm pack --dry-run` output unchanged (same 11 files), so publishing is unaffected.

Consumers can drop the `npm config set install-links true` workaround once this is
released.