### PR TITLE
Load yargs with dynamic import so Node 22.x before 22.12 works

### DIFF
--- a/json-sort.js
+++ b/json-sort.js
@@ -6,9 +6,12 @@ const fs = require('fs').promises;
 const os = require('os');
 const path = require('path');
 const process = require('node:process');
-const yargs = require('yargs/yargs');
 const { glob } = require('glob');
-const { hideBin } = require('yargs/helpers');
+
+// yargs 18 is ESM-only. `require()` of an ES module only works on Node 22.12.0
+// and later, so requiring it here would throw ERR_REQUIRE_ESM on earlier 22.x
+// releases even though package.json allows them. Load it with dynamic import()
+// instead, which works on every supported version.
 
 const opt = require('./src/options');
 const formatter = require('./src/formatter');
@@ -97,6 +100,9 @@ async function expandGlobs(argvUnderscore) {
  * @returns {object} The parsed arguments from yargs.
  */
 async function parseArguments(argumentsToParse) {
+  const { default: yargs } = await import('yargs/yargs');
+  const { hideBin } = await import('yargs/helpers');
+
   return await yargs(hideBin(argumentsToParse))
     .usage('Usage: $0 <file.json> [options]')
     .option('autofix', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tillig/json-sort-cli",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tillig/json-sort-cli",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "diff": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -39,5 +39,5 @@
     "test": "mocha",
     "verify": "npm run lint && npm run test"
   },
-  "version": "3.0.2"
+  "version": "3.0.3"
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,81 @@
+const assert = require('assert');
+const { execFile } = require('child_process');
+const fs = require('fs').promises;
+const os = require('os');
+const path = require('path');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(execFile);
+const cli = path.join(__dirname, '..', 'json-sort.js');
+
+/**
+ * Runs the CLI and resolves with the exit code and output regardless of whether
+ * the process exits non-zero, which it does whenever a file needs sorting.
+ * @param {string[]} args Arguments to pass to the CLI.
+ * @returns {Promise<object>} The exit code, stdout, and stderr.
+ */
+async function runCli(args) {
+  try {
+    const { stdout, stderr } = await execFileAsync(process.execPath, [cli, ...args]);
+    return { code: 0, stdout, stderr };
+  } catch (e) {
+    return { code: e.code, stdout: e.stdout, stderr: e.stderr };
+  }
+}
+
+describe('cli', function () {
+  // Spawning a process per test is slower than the unit tests.
+  this.timeout(20000);
+
+  let tempDirectory;
+
+  beforeEach(async function () {
+    tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'json-sort-cli-test'));
+  });
+
+  afterEach(async function () {
+    await fs.rm(tempDirectory, { force: true, recursive: true });
+  });
+
+  // yargs 18 is ESM-only, and `require()` of an ES module throws
+  // ERR_REQUIRE_ESM before Node 22.12.0. These tests exercise the entry point
+  // end to end so reintroducing a top-level `require('yargs/yargs')` fails the
+  // build instead of only breaking consumers on older Node 22 releases.
+  it('loads yargs without an ESM require error', async function () {
+    const result = await runCli(['--help']);
+
+    assert.strictEqual(result.code, 0);
+    assert.doesNotMatch(result.stderr, /ERR_REQUIRE_ESM/);
+    assert.match(result.stdout, /Usage: /);
+  });
+
+  it('reports an unsorted file', async function () {
+    const target = path.join(tempDirectory, 'unsorted.json');
+    await fs.writeFile(target, '{"b":1,"a":2}\n');
+
+    const result = await runCli([target]);
+
+    assert.strictEqual(result.code, 1);
+    assert.doesNotMatch(result.stderr, /ERR_REQUIRE_ESM/);
+    assert.match(result.stderr, /is not properly sorted/);
+  });
+
+  it('sorts a file when autofix is specified', async function () {
+    const target = path.join(tempDirectory, 'autofix.json');
+    await fs.writeFile(target, '{"b":1,"a":2}\n');
+
+    await runCli(['--autofix', target]);
+
+    const actual = await fs.readFile(target, 'utf8');
+    assert.strictEqual(actual, '{\n  "a": 2,\n  "b": 1\n}');
+  });
+
+  it('exits zero for a file that is already sorted', async function () {
+    const target = path.join(tempDirectory, 'sorted.json');
+    await fs.writeFile(target, '{\n  "a": 2,\n  "b": 1\n}');
+
+    const result = await runCli([target]);
+
+    assert.strictEqual(result.code, 0);
+  });
+});


### PR DESCRIPTION
## Problem

The hook crashes on runners with Node 22.4.1:

```text
Error [ERR_REQUIRE_ESM]: require() of ES Module .../node_modules/yargs/index.mjs not supported.
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at Object.<anonymous> (.../json-sort.js:9:15)
```

`yargs` 18 is ESM-only, and Node only supports `require()` of an ES module from
**22.12.0** onward. We declare `engines: >=22`, so every 22.x release below 22.12
was broken. yargs itself declares `^20.19.0 || ^22.12.0 || >=23`, which npm reports
as `EBADENGINE` — upstream agrees 22.12 is the floor.

Note the stack frame: OneAgent's `LD_PRELOAD` instrumentation wraps
`diagnostics_channel`'s `traceSync`, so Dynatrace appeared in the trace and the
failure looked like an APM problem. It isn't — this reproduces with no Dynatrace at
all, purely on Node < 22.12.

## Why it surfaced only now

The executable never actually ran before v3.0.2. The `build`-script/`install-links`
bug (#245) left a dangling bin symlink, so consumers failed earlier with
`Executable json-sort not found` and never reached module load. Fixing the install
exposed this pre-existing incompatibility — v3.0.0 had ESM yargs 18 too.

## Fix

`parseArguments` is already `async` and is the only consumer of both yargs entry
points, so it loads them with `import()` instead of top-level `require()`. yargs 18's
runtime works fine on 22.4.1 this way; its `engines` field only constrains `require()`.

## Verification

Reproduced and fixed on real CI (`ci-scale-set`, Node 22.4.1, OneAgent active via
`LD_PRELOAD`):

| | Before | After |
| --- | --- | --- |
| `ERR_REQUIRE_ESM` | thrown | absent |
| stderr | full minified OneAgent bundle | `Updating file sample.json (structure).` |

Locally verified on Node **22.4.1, 22.11.0, 22.12.0, 22.13.1, and 26** — and bisected
the boundary to 22.12.0, where `require(esm)` landed.

Also confirmed `--help`, `--version`, option parsing (`--indent-size=tab` emits real
tabs), and the no-arguments validation error all still work.

New `test/cli.test.js` exercises the entry point end to end. All four tests fail with
the old top-level `require` on Node 22.4.1 and pass with the import, so a regression
can't slip back in silently.

Full suite: 21 passing (17 existing + 4 new), lint clean, `npm pack` unchanged at 11 files.